### PR TITLE
Fix punctuation

### DIFF
--- a/components/SimpleContact.php
+++ b/components/SimpleContact.php
@@ -132,17 +132,17 @@ class SimpleContact extends ComponentBase
          * Form validation
          */
         $customValidationMessages = [
-            'name.required' => e(trans('zainab.simplecontact::validation.custom.name.required')),
-            'email.required' => e(trans('zainab.simplecontact::validation.custom.email.required')),
-            'email.email' => e(trans('zainab.simplecontact::validation.custom.email.email')),
-            'subject.required' => e(trans('zainab.simplecontact::validation.custom.subject.required')),
-            'message.required' => e(trans('zainab.simplecontact::validation.custom.message.required'))
+            'name.required' => trans('zainab.simplecontact::validation.custom.name.required'),
+            'email.required' => trans('zainab.simplecontact::validation.custom.email.required'),
+            'email.email' => trans('zainab.simplecontact::validation.custom.email.email'),
+            'subject.required' => trans('zainab.simplecontact::validation.custom.subject.required'),
+            'message.required' => trans('zainab.simplecontact::validation.custom.message.required'),
         ];
         $formValidationRules = [
             'name' => 'required',
             'email' => 'required|email',
             'subject' => 'required',
-            'message' => 'required'
+            'message' => 'required',
         ];
 
         $validator = Validator::make(post(), $formValidationRules,$customValidationMessages);


### PR DESCRIPTION
Remove `e` function which breaks punctuation, for example this Czech (cs) validation message:

![snimek obrazovky 2017-02-06 v 13 35 48](https://cloud.githubusercontent.com/assets/374917/22647526/476f7758-ec72-11e6-954f-6f6a132bb77d.png)

It should be "Zadejte prosím vaše jméno!".

I think that we don't really need te `e` filter, because validation messages are directly taken from language files.
